### PR TITLE
 Update .gitignore to Include Commonly Excluded Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,45 @@
+# Java IDE files
 .classpath
 .project
-.settings
-target/
+.settings/
 .idea/
 *.iml
 **/.factorypath
+
+# Build folders
+target/
 .vs/
 [Dd]ebug/
 [Rr]elease/
 .jpb/
+
+# OS generated files
+.DS_Store
+*.swp
+*~
+._*
+
+# Compiled code
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Package files
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# Logging files
+*.log
+*.sql
+*.sqlite
+
+# DevBootstrapper & x64 x86
+common/src/main/java/dk/digitalidentity/common/dao/bootstrap/DevBootstrapper.java
 #x64/
 #x86/
-
-common/src/main/java/dk/digitalidentity/common/dao/bootstrap/DevBootstrapper.java


### PR DESCRIPTION
This pull request updates the .gitignore file to include a comprehensive list of file types and directories that are commonly excluded in similar projects. The additions are based on best practices for Java development and aim to prevent system-generated files, IDE settings, and build artifacts from being accidentally committed to the repository. This change will help maintain the repository's cleanliness and ensure that only relevant source code and resources are tracked.